### PR TITLE
Use default http.Client instead of creating a new one

### DIFF
--- a/ld/document_loader.go
+++ b/ld/document_loader.go
@@ -37,12 +37,10 @@ type DefaultDocumentLoader struct {
 
 // NewDefaultDocumentLoader creates a new instance of DefaultDocumentLoader
 func NewDefaultDocumentLoader(httpClient *http.Client) *DefaultDocumentLoader {
-	rval := &DefaultDocumentLoader{}
+	rval := &DefaultDocumentLoader{httpClient: httpClient}
 
-	if httpClient != nil {
-		rval.httpClient = httpClient
-	} else {
-		rval.httpClient = &http.Client{}
+	if rval.httpClient == nil {
+		rval.httpClient = http.DefaultClient
 	}
 	return rval
 }


### PR DESCRIPTION
This commit follows the default logic I've seen so far: if nil `http.Client` is passed, use `http.DefaultClient` instead of creating a new one.

There is the reason for this, according to [docs](https://golang.org/pkg/net/http/#Client):

> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed.
