### PR TITLE
N-Quads deserialize from Reader, serialize to Writer

### DIFF
--- a/ld/document_loader_test.go
+++ b/ld/document_loader_test.go
@@ -1,8 +1,10 @@
 package ld_test
 
 import (
+	"bytes"
 	. "github.com/kazarena/json-gold/ld"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -12,6 +14,29 @@ func TestLoadDocument(t *testing.T) {
 	rd, _ := dl.LoadDocument("testdata/expand-0002-in.jsonld")
 
 	assert.Equal(t, "t1", rd.Document.(map[string]interface{})["@type"])
+}
+
+func loadBenchData(t testing.TB) *RDFDataset {
+	dl := NewDefaultDocumentLoader(nil)
+	rd, err := dl.LoadDocument("testdata/compact-manifest.jsonld")
+	require.Nil(t, err)
+	proc := NewJsonLdProcessor()
+	triples, err := proc.ToRDF(rd, NewJsonLdOptions(""))
+	require.Nil(t, err)
+	return triples.(*RDFDataset)
+}
+
+func BenchmarkLoadNQuads(b *testing.B) {
+	buf := bytes.NewBuffer(nil)
+	err := (&NQuadRDFSerializer{}).SerializeTo(buf, loadBenchData(b))
+	require.Nil(b, err)
+
+	data := buf.Bytes()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err = ParseNQuadsFrom(data)
+		require.Nil(b, err)
+	}
 }
 
 func TestParseLinkHeader(t *testing.T) {

--- a/ld/errors.go
+++ b/ld/errors.go
@@ -57,6 +57,7 @@ const (
 	UnknownFormat  ErrorCode = "unknown format"
 	InvalidInput   ErrorCode = "invalid input"
 	ParseError     ErrorCode = "parse error"
+	IOError        ErrorCode = "io error"
 	UnknownError   ErrorCode = "unknown error"
 )
 

--- a/ld/rdf_dataset.go
+++ b/ld/rdf_dataset.go
@@ -2,6 +2,7 @@ package ld
 
 import (
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 )
@@ -95,6 +96,11 @@ type RDFSerializer interface {
 
 	// Serialize an RDFDataset
 	Serialize(dataset *RDFDataset) (interface{}, error)
+}
+
+// RDFSerializerTo can serialize RDFDatasets into io.Writer.
+type RDFSerializerTo interface {
+	SerializeTo(w io.Writer, dataset *RDFDataset) error
 }
 
 // NewRDFDataset creates a new instance of RDFDataset.


### PR DESCRIPTION
Changed N-Quads code a bit:
1. Deserializer works with `bufio.Scanner` interface for line splitting, allowing to pass `io.Reader` as input to `Parse`. This should also reduce GC pressure on large datasets, because deserializer processes lines on the fly without a need to store them in a separate slice. Performance impact is minimal, as `newScannerFor` switches Scanner interface to custom implementation for `[]byte` and `string` to bypass copy operations in original `bufio.Scanner`. There is also a benchmark for that.
2. Serializers can implement an optional `RDFSerializerTo` interface advertising it's ability to write serialized RDF directly into `io.Writer` without a need of temporary string representation. N-Quads serializer implements such behavior now.

All changes are backward-compatible.
